### PR TITLE
Fix run and run_all sometimes returning values in an incorrect order

### DIFF
--- a/lib/ex_logic.ex
+++ b/lib/ex_logic.ex
@@ -291,14 +291,12 @@ defmodule ExLogic do
         Enum.map(Map.keys(s), fn var -> ExLogic.Goals.reify(var) end)
       end)
       |> List.flatten()
-      |> MapSet.new()
-      |> MapSet.to_list()
+      |> Enum.uniq()
 
     Enum.map(reified_vars, fn var -> Enum.map(substitutions, var) end)
     |> Enum.map(fn names ->
-      Enum.reject(names, fn name -> not valid?(name) end)
-      |> MapSet.new()
-      |> MapSet.to_list()
+      Enum.filter(names, fn name -> valid?(name) end)
+      |> Enum.uniq()
     end)
   end
 

--- a/test/ex_logic_test.exs
+++ b/test/ex_logic_test.exs
@@ -51,9 +51,6 @@ defmodule ExLogicTest do
 
   describe "fresh macro tests" do
     test "returns the correct conjunction (doctest)" do
-      Var.new("x")
-      Var.new("y")
-
       g =
         fresh([x, y]) do
           Goals.eq(x, :garlic)
@@ -88,6 +85,21 @@ defmodule ExLogicTest do
                },
                %{y => :oil}
              ]
+    end
+  end
+
+  describe "run_all/1 macro tests" do
+    test "values are returned in the correct order" do
+      g =
+        run_all([x, y]) do
+          disj do
+            eq(x, "garlic")
+            eq(x, :olive)
+            eq(y, :oil)
+          end
+        end
+
+      assert g == [["garlic", :olive], [:oil]]
     end
   end
 end


### PR DESCRIPTION
Basically I forgot `Enum.uniq/1` existed and because of that the `run` and `run_all` macros would sometimes return values in a different order from how they were defined. This fixes that.