### PR TITLE
Fix run/1 macro refactor tests

### DIFF
--- a/lib/ex_logic.ex
+++ b/lib/ex_logic.ex
@@ -243,12 +243,11 @@ defmodule ExLogic do
       ...>    eq(y, :oil)
       ...>   end
       ...> end
-      [[:olive, "_0"], [:oil, "_0"]]
+      [[:olive, "_0"], ["_0", :oil]]
 
       iex> run(1, [x, y]) do
-      ...>    eq(x, :olive)
-      ...>    eq(y, x)
-      ...>   end
+      ...>   eq(x, :olive)
+      ...>   eq(y, x)
       ...> end
       [[:olive, :olive]]
 
@@ -290,7 +289,7 @@ defmodule ExLogic do
 
   ## Examples
 
-      iex> run_all([x, y]) do
+      iex> run([x, y]) do
       ...>  disj do
       ...>    eq(x, :olive)
       ...>    eq(x, :oil)

--- a/lib/substitution.ex
+++ b/lib/substitution.ex
@@ -54,7 +54,8 @@ defmodule ExLogic.Substitution do
   @spec walk_all(ExLogic.value(), Substitution.t()) :: ExLogic.value()
   def walk_all(v, r) do
     case walk(v, r) do
-      [h | t] -> [walk_all(h, r) | walk_all(t, r)] # TODO: make tail recursive version
+      # TODO: make tail recursive version
+      [h | t] -> [walk_all(h, r) | walk_all(t, r)]
       v -> v
     end
   end

--- a/test/ex_logic_test.exs
+++ b/test/ex_logic_test.exs
@@ -88,10 +88,10 @@ defmodule ExLogicTest do
     end
   end
 
-  describe "run_all/1 macro tests" do
+  describe "run/1 macro tests" do
     test "values are returned in the correct order" do
       g =
-        run_all([x, y]) do
+        run([x, y]) do
           disj do
             eq(x, "garlic")
             eq(x, :olive)
@@ -99,7 +99,7 @@ defmodule ExLogicTest do
           end
         end
 
-      assert g == [["garlic", :olive], [:oil]]
+      assert g == [["garlic", "_0"], [:olive, "_0"], ["_0", :oil]]
     end
   end
 end


### PR DESCRIPTION
This PR fixes the test from the #6, I changed the name of the function tested in the doctests to match the one defined in that PR (`run/1`)